### PR TITLE
Update Basic Usage.ipynb

### DIFF
--- a/docs/Basic Usage.ipynb
+++ b/docs/Basic Usage.ipynb
@@ -155,7 +155,8 @@
     "plt.figure()\n",
     "plt.plot(x, y, \"o\")\n",
     "plt.plot(x, y_pred, \"-\")\n",
-    "plt.show()"
+    "plt.show()",
+    "bms_estimator.model_.latex()"
    ]
   },
   {


### PR DESCRIPTION
Single command added to print latex model at the end of the Basic Usage tutorial:

```
bms_estimator.model_.latex()
```
when not in the Jupyter notebook, a print statement will be needed single this function works by returning the latex model rather than by printing it.

Linking to issue #10 