### PR TITLE
Unused redundant function remove for clarity

### DIFF
--- a/src/autora/theorist/bms/regressor.py
+++ b/src/autora/theorist/bms/regressor.py
@@ -33,7 +33,7 @@ class BMSRegressor(BaseEstimator, RegressorMixin):
 
     Examples:
 
-        >>> from autora.theorist.bms import Parallel, utils
+        >>> from autora.theorist.bms import Parallel
         >>> import numpy as np
         >>> num_samples = 1000
         >>> X = np.linspace(start=0, stop=1, num=num_samples).reshape(-1, 1)

--- a/src/autora/theorist/bms/utils.py
+++ b/src/autora/theorist/bms/utils.py
@@ -63,27 +63,3 @@ def present_results(model: Tree, model_len: float, desc_len: List[float]) -> Non
     plt.ylabel("Description length", fontsize=14)
     plt.title("MDL model: $%s$" % model.latex())
     plt.show()
-
-
-def predict(model: Tree, x: pd.DataFrame, y: pd.DataFrame) -> dict:
-    """
-    Maps independent variable data onto expected dependent variable data
-
-    Args:
-        model: The equation / function that best maps x onto y
-        x: The independent variables of the data
-        y: The dependent variable of the data
-
-    Returns: Predicted values for y given x and the model as trained
-    """
-    plt.figure(figsize=(6, 6))
-    plt.scatter(model.predict(x), y)
-
-    all_y = np.append(y, model.predict(x))
-    y_range = all_y.min().item(), all_y.max().item()
-    plt.plot(y_range, y_range)
-
-    plt.xlabel("MDL model predictions", fontsize=14)
-    plt.ylabel("Actual values", fontsize=14)
-    plt.show()
-    return model.predict(x)


### PR DESCRIPTION
## What this PR includes
Unused redundant predict function removed from utils.py for clarity

## Explanation
The predict function is called by BMSRegressor and directly uses the Tree objects in mcmc.py

### Extra details:
The utils.py file is not involved. An optional ```present_results``` function has been left since it has a unique name and functionality.

### Notes:
A worthwhile refactoring at this point would be to remove the utils.py file altogether and move the ```run``` function into BMSRegressor ```fit``` method, since it is quite short and straightforward.

### Related Issues:
This resolves issue #4 