### PR TITLE
Additional exception handling to prevent complex-valued parameters

### DIFF
--- a/src/autora/theorist/bms/mcmc.py
+++ b/src/autora/theorist/bms/mcmc.py
@@ -701,6 +701,10 @@ class Tree:
                 if verbose:
                     print("> Cannot calculate SSE for %s: inf" % self, file=sys.stderr)
                 self.sse[ds] = np.inf
+            except TypeError:
+                if verbose:
+                    print("Complex-valued parameters are invalid")
+                self.sse[ds] = np.inf
 
         # Done
         return self.sse
@@ -725,11 +729,12 @@ class Tree:
         k = 1 + len(parameters)
         BIC = 0.0
         for ds in self.y:
-            n = len(self.y[ds])
-            BIC += (k - n) * np.log(n) + n * (np.log(2.0 * np.pi) + log(sse[ds]) + 1)
-        for ds in self.y:
             if sse[ds] == 0.0:
                 BIC = -np.inf
+                break
+            else:
+                n = len(self.y[ds])
+                BIC += (k - n) * np.log(n) + n * (np.log(2.0 * np.pi) + log(sse[ds]) + 1)
         if reset:
             self.bic = BIC
         return BIC
@@ -790,6 +795,8 @@ class Tree:
         canonical = self.canonical(verbose=verbose)
         try:  # We've seen this canonical before!
             rep, rep_energy, rep_par_values = self.representative[canonical]
+        except TypeError:
+            return -1  # Complex-valued parameters are invalid
         except KeyError:  # Never seen this canonical formula before:
             # save it and return 1
             self.get_bic(reset=True, fit=True, verbose=verbose)


### PR DESCRIPTION
Resolves issue #19 

This is needed to prevent BMS from crashing

It was concerning to run into this error while making the BMS tutorial notebook as I thought this had been resolved. At this point, I have a very good idea of how to resolve it. This should hopefully resolve it.

Additional exception handling was included for ```TypeError``` which occurs when ```scipy.optimize.curve_fit``` returns complex-valued parameters. The way the code is written makes it hard to prevent this from causing errors (which is part of why the original code may have lacked proper except clauses.